### PR TITLE
chore: Minor change to remove www from github url in Cargo.toml

### DIFF
--- a/adventage-macros/Cargo.toml
+++ b/adventage-macros/Cargo.toml
@@ -2,7 +2,7 @@
 name = "adventage-macros"
 version = "0.3.0"
 edition = "2021"
-repository = "https://www.github.com/3ach/adventage"
+repository = "https://github.com/3ach/adventage"
 license = "MIT"
 description = "Advent of Code, easier!"
 

--- a/adventage/Cargo.toml
+++ b/adventage/Cargo.toml
@@ -2,7 +2,7 @@
 name = "adventage"
 version = "0.3.0"
 edition = "2021"
-repository = "https://www.github.com/3ach/adventage"
+repository = "https://github.com/3ach/adventage"
 license = "MIT"
 description = "Advent of Code, easier!"
 


### PR DESCRIPTION
GitHub redirects to the address without www anyway, so let's put that in Cargo.toml See also https://github.com/szabgab/rust-digger/issues/96